### PR TITLE
Set state for all parameters

### DIFF
--- a/taxcalc/parameters.py
+++ b/taxcalc/parameters.py
@@ -424,6 +424,7 @@ class Parameters(pt.Parameters):
         # Re-instate ops.
         self.label_to_extend = label_to_extend
         self.array_first = array_first
+        self.set_state()
 
         # Filter out "-indexed" params.
         nonindexed_params = {
@@ -431,10 +432,6 @@ class Parameters(pt.Parameters):
             for param, val in params.items()
             if param not in index_affected
         }
-
-        needs_reset = set(needs_reset) - set(nonindexed_params.keys())
-        if needs_reset:
-            self._set_state(params=needs_reset)
 
         # 3. Do adjustment for all non-indexing related parameters.
         adj = super().adjust(nonindexed_params, **kwargs)


### PR DESCRIPTION
This fixes the failing test, but I'm not 100% sure why this is causing a problem with ParamTools 0.16.1. I'll continue looking into this.

A bunch of smaller updates are done while doing the main parameter value update. The operators for converting parameter values to NumPy arrays and then extending them throughout the budget window are turned off so that we aren't doing extra work after each of these smaller updates. 

https://github.com/PSLmodels/Tax-Calculator/blob/565158d4385901be0ef5c5f9332a5e567587e9e5/taxcalc/parameters.py#L190-L194

https://github.com/PSLmodels/Tax-Calculator/blob/565158d4385901be0ef5c5f9332a5e567587e9e5/taxcalc/parameters.py#L334

Then once they are done, the operators are turned back on and the parameters that need to be converted to NumPy arrays or extended through the budget window are updated.

https://github.com/PSLmodels/Tax-Calculator/blob/565158d4385901be0ef5c5f9332a5e567587e9e5/taxcalc/parameters.py#L424-L437

 However, it seems like a lot of the parameter values (including `UBI_ecrt`) were not converted to NumPy arrays. If I just reset the values for all parameters, then the test passes. I'm going to do some more digging to figure out why 0.16.0 is causing this behavior. In the meantime, this should get all unit tests passing again.

@jdebacker @peter-metz